### PR TITLE
support separate aws account for s3 backend bucket

### DIFF
--- a/lib/terraspace_plugin_aws/clients.rb
+++ b/lib/terraspace_plugin_aws/clients.rb
@@ -6,6 +6,7 @@ require "aws-sdk-ssm"
 module TerraspacePluginAws
   module Clients
     extend Memoist
+    include Options
 
     def s3
       Aws::S3::Client.new(client_options)
@@ -26,14 +27,5 @@ module TerraspacePluginAws
       Aws::DynamoDB::Client.new(client_options)
     end
     memoize :dynamodb
-
-    # Typically inferred from AWS_REGION unless set in the backend.tf
-    def client_options
-      if @info['region']
-        {region: @info['region']}
-      else
-        {}
-      end
-    end
   end
 end

--- a/lib/terraspace_plugin_aws/clients/options.rb
+++ b/lib/terraspace_plugin_aws/clients/options.rb
@@ -1,0 +1,100 @@
+module TerraspacePluginAws::Clients
+  module Options
+  private
+    def client_options
+      if @info['role_arn']
+        client_assume_role_config
+      else
+        client_default_options
+      end
+    end
+
+    # Typically, aws sdk client options are inferred from the user environment unless set in the backend.tf
+    #
+    # terraform s3 backend assume role configuration: https://www.terraform.io/docs/language/settings/backends/s3.html
+    #
+    #     assume_role_duration_seconds - (Optional) Number of seconds to restrict the assume role session duration.
+    #     assume_role_policy - (Optional) IAM Policy JSON describing further restricting permissions for the IAM Role being assumed.
+    #     assume_role_policy_arns - (Optional) Set of Amazon Resource Names (ARNs) of IAM Policies describing further restricting permissions for the IAM Role being assumed.
+    #     assume_role_tags - (Optional) Map of assume role session tags.
+    #     assume_role_transitive_tag_keys - (Optional) Set of assume role session tag keys to pass to any subsequent sessions.
+    #     external_id - (Optional) External identifier to use when assuming the role.
+    #     role_arn - (Optional) Amazon Resource Name (ARN) of the IAM Role to assume.
+    #     session_name - (Optional) Session name to use when assuming the role.
+    #
+    # ruby sdk: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/AssumeRoleCredentials.html
+    #
+    #     :role_arn (required, String)
+    #     :role_session_name (required, String)
+    #     :policy (String)
+    #     :duration_seconds (Integer)
+    #     :external_id (String)
+    #     :client (STS::Client)
+    #
+    def client_assume_role_config
+      whitelist = %w[
+        assume_role_duration_seconds
+        assume_role_policy
+        session_name
+        external_id
+        role_arn
+      ]
+      assume_role_config = @info.slice(*whitelist)
+      # not supported?
+      #   assume_role_policy_arns
+      #   assume_role_tags
+      #   assume_role_transitive_tag_keys
+      # already matches
+      #   external_id
+      #   role_arn
+      # rest needs to be mapped
+      map = {
+        'assume_role_duration_seconds' => 'duration_seconds',
+        'assume_role_policy' => 'policy',
+        'session_name' => 'role_session_name',
+      }
+      map.each do |terraform_key, ruby_sdk_key|
+        v = assume_role_config.delete(terraform_key)
+        assume_role_config[ruby_sdk_key] = v if v
+      end
+      assume_role_config.symbolize_keys! # ruby sdk expects symbols for keys
+      assume_role_config[:role_session_name] ||= [ENV['C9_USER'] || ENV['USER'], 'session'].compact.join('-') # session name is required for the ruby sdk
+      # options = {client: Aws::STS::Client.new(client_region_option)}
+      options = {}
+      options.merge!(assume_role_config)
+      role_credentials = Aws::AssumeRoleCredentials.new(options)
+      {credentials: role_credentials}
+    end
+
+    # terraform s3 backend configuration: https://www.terraform.io/docs/language/settings/backends/s3.html
+    #
+    #     access_key - (Optional) AWS access key. If configured, must also configure secret_key. This can also be sourced from the AWS_ACCESS_KEY_ID environment variable, AWS shared credentials file (e.g. ~/.aws/credentials), or AWS shared configuration file (e.g. ~/.aws/config).
+    #     secret_key - (Optional) AWS access key. If configured, must also configure access_key. This can also be sourced from the AWS_SECRET_ACCESS_KEY environment variable, AWS shared credentials file (e.g. ~/.aws/credentials), or AWS shared configuration file (e.g. ~/.aws/config).
+    #
+    # ruby sdk: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Credentials.html
+    #
+    #     access_key_id (String)
+    #     secret_access_key (String)
+    #     session_token (String) (defaults to: nil) — (nil)
+    #
+    def client_default_options
+      whitelist = %w[
+        access_key_id
+        secret_access_key
+        session_token
+        profile
+      ]
+      options = @info.slice(*whitelist)
+      options.symbolize_keys! # ruby sdk expects symbols for keys
+      client_region_option.merge(options)
+    end
+
+    def client_region_option
+      if @info['region']
+        {region: @info['region']}
+      else
+        {}
+      end
+    end
+  end
+end

--- a/lib/terraspace_plugin_aws/interfaces/backend/bucket/secure.rb
+++ b/lib/terraspace_plugin_aws/interfaces/backend/bucket/secure.rb
@@ -2,6 +2,27 @@ require "s3-secure"
 
 class TerraspacePluginAws::Interfaces::Backend::Bucket
   module Secure
+    # Why the retry logic?
+    #
+    # When using profile or role_arn in the terraform backend it the ruby aws sdk
+    # assumes the profile or role.
+    # In doing so, it errors when the s3-secure library calls s3_client.get_bucket_location
+    #
+    #   https://github.com/boltops-tools/s3-secure/blob/d2c8e9eba745a75d094a3c566bd5fe47476d3638/lib/s3_secure/aws_services/s3.rb#L43
+    #
+    # Here's an example stack trace of the error:
+    #
+    #   https://gist.github.com/tongueroo/dd74b67c17433c6f8dd890225104aef9
+    #
+    # Unsure if this is a terraform backend interfering with the ruby sdk thing (unlikely)
+    # Or if it's a general AWS sdk thing.
+    # Or if it's how I'm calling the sdk and initializing the client. Maybe an initializing the client early on and it caches it.
+    # Unsure. But using this hack instead because life's short.
+    #
+    # Throwing the retry logic in here fixes the issue. This only happens the when the bucket is brand new.
+    # Limiting the retry to only a single attempt.
+    #
+    @@retries = 0
     def secure(bucket)
       c = TerraspacePluginAws::Interfaces::Config.instance.config.s3
       options = {bucket: bucket, quiet: true}
@@ -10,6 +31,9 @@ class TerraspacePluginAws::Interfaces::Backend::Bucket
       S3Secure::Versioning::Enable.new(options).run if c.versioning
       S3Secure::Lifecycle::Add.new(options).run if c.lifecycle
       S3Secure::AccessLogs::Enable.new(options).run if c.access_logging
+    rescue Aws::S3::Errors::AccessDenied => e
+      @@retries += 1
+      retry unless @@retries > 1
     end
   end
 end


### PR DESCRIPTION
* detect role_arn and create s3 client based on it
* detect profile and respect it also

Fixes #6 

Related #8 