### PR TITLE
Check to see if @info is null before creating client

### DIFF
--- a/lib/terraspace_plugin_aws/clients.rb
+++ b/lib/terraspace_plugin_aws/clients.rb
@@ -9,22 +9,38 @@ module TerraspacePluginAws
     include Options
 
     def s3
-      Aws::S3::Client.new(client_options)
+      if @info
+        Aws::S3::Client.new(client_options)
+      else
+        Aws::S3::Client.new
+      end
     end
     memoize :s3
 
     def secretsmanager
-      Aws::SecretsManager::Client.new(client_options)
+      if @info
+        Aws::SecretsManager::Client.new(client_options)
+      else
+        Aws::SecretsManager::Client.new
+      end
     end
     memoize :secretsmanager
 
     def ssm
-      Aws::SSM::Client.new(client_options)
+      if @info
+        Aws::SSM::Client.new(client_options)
+      else
+        Aws::SSM::Client.new
+      end
     end
     memoize :ssm
 
     def dynamodb
-      Aws::DynamoDB::Client.new(client_options)
+      if @info
+        Aws::DynamoDB::Client.new(client_options)
+      else
+        Aws::DynamoDB::Client.new
+      end
     end
     memoize :dynamodb
   end


### PR DESCRIPTION
Apologies beforehand if this is a bit naive or un-ruby-esque. Welcome to suggestions and changes.

This is to add a simple check that options are being passed in before creating clients. 
Prevents any null related errors within Options.

Solves issue #11 