### PR TITLE
fix bucket tagging: use parsed region from backend.tf for s3 client

### DIFF
--- a/lib/terraspace_plugin_aws/interfaces/backend/bucket.rb
+++ b/lib/terraspace_plugin_aws/interfaces/backend/bucket.rb
@@ -34,7 +34,7 @@ class TerraspacePluginAws::Interfaces::Backend
     end
 
     def tag(bucket)
-      Tagging.new(@info["bucket"]).tag
+      Tagging.new(@info).tag
     end
   end
 end

--- a/lib/terraspace_plugin_aws/interfaces/backend/bucket/tagging.rb
+++ b/lib/terraspace_plugin_aws/interfaces/backend/bucket/tagging.rb
@@ -1,10 +1,8 @@
 class TerraspacePluginAws::Interfaces::Backend::Bucket
-  class Tagging
-    include TerraspacePluginAws::Clients
-    include TerraspacePluginAws::Logging
-
-    def initialize(bucket)
-      @bucket = bucket
+  class Tagging < TerraspacePluginAws::Interfaces::Backend::Base
+    def initialize(info)
+      super
+      @bucket = info['bucket']
     end
 
     def tag


### PR DESCRIPTION
Related https://community.boltops.com/t/cannot-seem-to-use-vars-within-tf-files/897/3