### PR TITLE
Remove redundant backend `encrypt` configuration

### DIFF
--- a/lib/templates/hcl/project/config/terraform/backend.tf.tt
+++ b/lib/templates/hcl/project/config/terraform/backend.tf.tt
@@ -6,7 +6,6 @@ terraform {
     bucket         = "<%%= expansion('terraform-state-:ACCOUNT-:REGION-:ENV') %>"
     key            = "<%%= expansion(':PROJECT/:REGION/:APP/:ROLE/:ENV/:EXTRA/:BUILD_DIR/terraform.tfstate') %>"
     region         = "<%%= expansion(':REGION') %>"
-    encrypt        = true
     dynamodb_table = "terraform_locks"
   }
 }


### PR DESCRIPTION
Since January 2023, server side encryption of all new S3 objects is enabled by default and this can't be disabled, so there's no point configuring it explicitly.

See
https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-encryption-faq.html